### PR TITLE
Allow building with containers-0.6

### DIFF
--- a/ordered-containers.cabal
+++ b/ordered-containers.cabal
@@ -19,7 +19,7 @@ library
   exposed-modules:     Data.Map.Ordered, Data.Set.Ordered
   other-modules:       Data.Map.Util
   -- other-extensions:    
-  build-depends:       base >=4 && <5, containers >=0.1 && <0.6
+  build-depends:       base >=4 && <5, containers >=0.1 && <0.7
   -- hs-source-dirs:      
   default-language:    Haskell98
   ghc-options:         -fno-warn-tabs


### PR DESCRIPTION
This is needed to build `ordered-containers` with GHC 8.6.1.