### PR TITLE
Add (|<>) and (<>|) to Data.Map.Ordered

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,13 @@
 # Revision history for ordered-containers
 
+## next -- ????-??-??
+
+* Add `(|<>)` and `(<>|)` to `Data.Map.Ordered`
+
+## 0.1.1 -- 2018-11-01
+
+* Allow building with `containers-0.6`
+
 ## 0.1.0 -- 2016-12-26
 
 * Documentation fix


### PR DESCRIPTION
Curiously, these were defined in `Data.Set.Ordered`, but not in `Data.Map.Ordered`. I found myself needing the `OMap` versions of these functions recently, so this patch adds them.

```
λ> assocs $ fromList [(2,"hello")] |<> fromList [(1,"world")]
[(2,"hello"),(1,"world")]
λ> assocs $ fromList [(1,"hello")] |<> fromList [(1,"world")]
[(1,"hello")]
λ> assocs $ fromList [(1,"hello")] <>| fromList [(1,"world")]
[(1,"world")]
```