### PR TITLE
Add Data/Typeable instances for OMap and OSet

### DIFF
--- a/Data/Set/Ordered.hs
+++ b/Data/Set/Ordered.hs
@@ -1,3 +1,8 @@
+{-# LANGUAGE CPP #-}
+#if __GLASGOW_HASKELL__
+{-# LANGUAGE DeriveDataTypeable, StandaloneDeriving #-}
+#endif
+
 -- | An 'OSet' behaves much like a 'Set', with all the same asymptotics, but
 -- also remembers the order that values were inserted.
 module Data.Set.Ordered
@@ -33,6 +38,10 @@ import Data.Set (Set) -- so the haddocks link to the right place
 import Prelude hiding (filter, foldr, lookup, null)
 import qualified Data.Map as M
 
+#if __GLASGOW_HASKELL__
+import Data.Data
+#endif
+
 data OSet a = OSet !(Map a Tag) !(Map Tag a)
 
 -- | Values appear in insertion order, not ascending order.
@@ -41,6 +50,32 @@ instance         Eq   a  => Eq   (OSet a) where (==)    = (==)    `on` toList
 instance         Ord  a  => Ord  (OSet a) where compare = compare `on` toList
 instance         Show a  => Show (OSet a) where showsPrec = showsPrecList toList
 instance (Ord a, Read a) => Read (OSet a) where readsPrec = readsPrecList fromList
+
+#if __GLASGOW_HASKELL__
+# if __GLASGOW_HASKELL__ >= 708
+deriving instance Typeable OSet
+# else
+deriving instance Typeable1 OSet
+# endif
+
+-- This instance preserves data abstraction at the cost of inefficiency.
+-- We provide limited reflection services for the sake of data abstraction.
+
+instance (Data a, Ord a) => Data (OSet a) where
+  gfoldl f z set = z fromList `f` (toList set)
+  toConstr _     = fromListConstr
+  gunfold k z c  = case constrIndex c of
+    1 -> k (z fromList)
+    _ -> error "gunfold"
+  dataTypeOf _   = oSetDataType
+  dataCast1 f    = gcast1 f
+
+fromListConstr :: Constr
+fromListConstr = mkConstr oSetDataType "fromList" [] Prefix
+
+oSetDataType :: DataType
+oSetDataType = mkDataType "Data.Set.Ordered.Set" [fromListConstr]
+#endif
 
 infixr 5 <|, |<   -- copy :
 infixl 5 >|, |>


### PR DESCRIPTION
These `Data`/`Typeable` instances (defined only when compiling with GHC) closely mirror the ones found in the `containers` library.

Fixes #6.