### PR TITLE
Add Hashable instances

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,9 @@
 # Revision history for ordered-containers
 
+## 0.2.3 -- unreleased
+
+* Add `Hashable` instances.
+
 ## 0.2.2 -- 2019-07-05
 
 * Add `toMap` and `toSet`, which support efficient conversions from

--- a/Data/Map/Ordered/Internal.hs
+++ b/Data/Map/Ordered/Internal.hs
@@ -10,6 +10,7 @@ import Control.Monad (guard)
 import Data.Data
 import Data.Foldable (Foldable, foldl', foldMap)
 import Data.Function (on)
+import Data.Hashable (Hashable(..))
 import Data.Map (Map)
 import Data.Map.Util
 import Data.Monoid (Monoid(..))
@@ -32,6 +33,7 @@ instance (       Eq   k, Eq   v) => Eq   (OMap k v) where (==)    = (==)    `on`
 instance (       Ord  k, Ord  v) => Ord  (OMap k v) where compare = compare `on` assocs
 instance (       Show k, Show v) => Show (OMap k v) where showsPrec = showsPrecList assocs
 instance (Ord k, Read k, Read v) => Read (OMap k v) where readsPrec = readsPrecList fromList
+instance (Hashable k, Hashable v) => Hashable (OMap k v) where hashWithSalt s = hashWithSalt s . assocs
 
 -- This instance preserves data abstraction at the cost of inefficiency.
 -- We provide limited reflection services for the sake of data abstraction.

--- a/Data/Set/Ordered.hs
+++ b/Data/Set/Ordered.hs
@@ -36,6 +36,7 @@ import Control.Monad (guard)
 import Data.Data
 import Data.Foldable (Foldable, foldl', foldMap, foldr, toList)
 import Data.Function (on)
+import Data.Hashable (Hashable(..))
 import Data.Map (Map)
 import Data.Map.Util
 import Data.Monoid (Monoid(..))
@@ -55,6 +56,7 @@ instance         Eq   a  => Eq   (OSet a) where (==)    = (==)    `on` toList
 instance         Ord  a  => Ord  (OSet a) where compare = compare `on` toList
 instance         Show a  => Show (OSet a) where showsPrec = showsPrecList toList
 instance (Ord a, Read a) => Read (OSet a) where readsPrec = readsPrecList fromList
+instance      Hashable a => Hashable (OSet a) where hashWithSalt s = hashWithSalt s . toList
 
 -- This instance preserves data abstraction at the cost of inefficiency.
 -- We provide limited reflection services for the sake of data abstraction.

--- a/ordered-containers.cabal
+++ b/ordered-containers.cabal
@@ -17,6 +17,6 @@ source-repository head
 library
   exposed-modules:     Data.Map.Ordered, Data.Map.Ordered.Strict, Data.Set.Ordered
   other-modules:       Data.Map.Ordered.Internal, Data.Map.Util
-  build-depends:       base >=4.7 && <5, containers >=0.1 && <0.7
+  build-depends:       base >=4.7 && <5, containers >=0.1 && <0.7, hashable <2
   default-language:    Haskell98
   ghc-options:         -fno-warn-tabs


### PR DESCRIPTION
This adds a dependency on `hashable`, but `hashable` is a tiny package, and most projects using this package probably already depend on it anyway.