### PR TITLE
Support `containers-0.7`

### DIFF
--- a/ordered-containers.cabal
+++ b/ordered-containers.cabal
@@ -17,6 +17,6 @@ source-repository head
 library
   exposed-modules:     Data.Map.Ordered, Data.Map.Ordered.Strict, Data.Set.Ordered
   other-modules:       Data.Map.Ordered.Internal, Data.Map.Util
-  build-depends:       base >=4.7 && <5, containers >=0.1 && <0.7
+  build-depends:       base >=4.7 && <5, containers >=0.1 && <0.8
   default-language:    Haskell98
   ghc-options:         -fno-warn-tabs


### PR DESCRIPTION
This raises the upper version bounds on `containers` to support building with `containers-0.7`, which is bundled with GHC 9.10.

Fixes #26.