### PR TITLE
Remove noncanonical definitions

### DIFF
--- a/Data/Map/Ordered/Internal.hs
+++ b/Data/Map/Ordered/Internal.hs
@@ -91,7 +91,9 @@ instance (Ord k, Semigroup v) => Semigroup (Bias R (OMap k v)) where
 -- @since 0.2
 instance (Ord k, Monoid v) => Monoid (Bias L (OMap k v)) where
 	mempty = Bias empty
+#if !MIN_VERSION_base(4,11,0)
 	mappend (Bias o) (Bias o') = Bias (unionWithL (const mappend) o o')
+#endif
 
 -- | Empty maps and map union. When combining two sets that share elements, the
 -- indices of the right argument are preferred, and the values are combined
@@ -102,7 +104,9 @@ instance (Ord k, Monoid v) => Monoid (Bias L (OMap k v)) where
 -- @since 0.2
 instance (Ord k, Monoid v) => Monoid (Bias R (OMap k v)) where
 	mempty = Bias empty
+#if !MIN_VERSION_base(4,11,0)
 	mappend (Bias o) (Bias o') = Bias (unionWithR (const mappend) o o')
+#endif
 
 -- | Values are traversed in insertion order, not key order.
 --

--- a/Data/Set/Ordered.hs
+++ b/Data/Set/Ordered.hs
@@ -103,7 +103,9 @@ instance Ord a => Semigroup (Bias R (OSet a)) where Bias o <> Bias o' = Bias (o 
 -- @since 0.2
 instance Ord a => Monoid (Bias L (OSet a)) where
 	mempty = Bias empty
+#if !MIN_VERSION_base(4,11,0)
 	mappend (Bias o) (Bias o') = Bias (o |<> o')
+#endif
 
 -- | Empty sets and set union. When combining two sets that share elements, the
 -- indices of the right argument are preferred.
@@ -113,7 +115,9 @@ instance Ord a => Monoid (Bias L (OSet a)) where
 -- @since 0.2
 instance Ord a => Monoid (Bias R (OSet a)) where
 	mempty = Bias empty
+#if !MIN_VERSION_base(4,11,0)
 	mappend (Bias o) (Bias o') = Bias (o <>| o')
+#endif
 
 infixr 5 <|, |<   -- copy :
 infixl 5 >|, |>


### PR DESCRIPTION
This appeases the -Wnoncanonical-monoid-instances warning. This warning exists because a future GHC release may treat noncanonical definitions as errors.

See also:
  https://gitlab.haskell.org/ghc/ghc/-/wikis/proposal/semigroup-monoid