### PR TITLE
Allow containers 0.8

### DIFF
--- a/ordered-containers.cabal
+++ b/ordered-containers.cabal
@@ -17,6 +17,6 @@ source-repository head
 library
   exposed-modules:     Data.Map.Ordered, Data.Map.Ordered.Strict, Data.Set.Ordered
   other-modules:       Data.Map.Ordered.Internal, Data.Map.Util
-  build-depends:       base >=4.7 && <5, containers >=0.1 && <0.8, hashable >=1.2 && <2.0
+  build-depends:       base >=4.7 && <5, containers >=0.1 && <0.9, hashable >=1.2 && <2.0
   default-language:    Haskell98
   ghc-options:         -fno-warn-tabs


### PR DESCRIPTION
Trying to make my pandoc buildable (which uses typst which uses ordered-containers).